### PR TITLE
[pm4-97] removed email from dto

### DIFF
--- a/backend/src/main/java/ch/zhaw/parkship/user/ParkshipUserDetails.java
+++ b/backend/src/main/java/ch/zhaw/parkship/user/ParkshipUserDetails.java
@@ -12,7 +12,6 @@ import java.util.List;
 @Getter
 public class ParkshipUserDetails implements UserDetails {
     private final Long id;
-    private final String email;
     private final String username;
     private final String name;
     private final String surname;
@@ -21,9 +20,8 @@ public class ParkshipUserDetails implements UserDetails {
     private final UserState userState;
 
     // Need explicit Constructor cause of Repository -> No lombok
-    public ParkshipUserDetails(Long id, String email, String username, String name, String surname, String password, UserRole userRole, UserState userState) {
+    public ParkshipUserDetails(Long id, String username, String name, String surname, String password, UserRole userRole, UserState userState) {
         this.id = id;
-        this.email = email;
         this.username = username;
         this.name = name;
         this.surname = surname;

--- a/backend/src/main/java/ch/zhaw/parkship/user/ParkshipUserDetails.java
+++ b/backend/src/main/java/ch/zhaw/parkship/user/ParkshipUserDetails.java
@@ -20,9 +20,9 @@ public class ParkshipUserDetails implements UserDetails {
     private final UserState userState;
 
     // Need explicit Constructor cause of Repository -> No lombok
-    public ParkshipUserDetails(Long id, String username, String name, String surname, String password, UserRole userRole, UserState userState) {
+    public ParkshipUserDetails(Long id, String email, String name, String surname, String password, UserRole userRole, UserState userState) {
         this.id = id;
-        this.username = username;
+        this.username = email;
         this.name = name;
         this.surname = surname;
         this.password = password;
@@ -53,5 +53,9 @@ public class ParkshipUserDetails implements UserDetails {
     @Override
     public boolean isEnabled() {
         return true;
+    }
+
+    public String getEmail(){
+        return getUsername();
     }
 }

--- a/backend/src/main/java/ch/zhaw/parkship/user/UserController.java
+++ b/backend/src/main/java/ch/zhaw/parkship/user/UserController.java
@@ -34,9 +34,8 @@ public class UserController {
     /**
      * Record for having the users request from the frontend to sign up in one clean object.
      *
-     * @param email
      */
-    public record SignUpRequestDTO(@NotBlank String name, @NotBlank String surname, @NotBlank @Email String email,  @NotNull UserRole role) {
+    public record SignUpRequestDTO(@NotBlank String name, @NotBlank String surname, @NotBlank String username, @NotNull UserRole role) {
     }
 
     /**
@@ -45,7 +44,7 @@ public class UserController {
      * @param id
      * @param username
      */
-    public record SignUpResponseDTO(Long id, String name, String surname, String email, String username, UserRole userRole, String password) {
+    public record SignUpResponseDTO(Long id, String name, String surname, String username, UserRole userRole, String password) {
     }
 
 
@@ -75,17 +74,16 @@ public class UserController {
     @PostMapping("/signup")
     @Secured("ADMIN")
     public SignUpResponseDTO signUp(@Valid @RequestBody SignUpRequestDTO signUpRequestDTO) {
-        if (userService.existsByEmail(signUpRequestDTO.email)) {
+        if (userService.existsByUsername(signUpRequestDTO.username)) {
             throw new ResponseStatusException(HttpStatus.CONFLICT);
         }
 
         String password = passwordGeneratorService.generatePassword();
-        UserEntity newUser = userService.signUp(signUpRequestDTO.name, signUpRequestDTO.surname, signUpRequestDTO.email,
+        UserEntity newUser = userService.signUp(signUpRequestDTO.name, signUpRequestDTO.surname, signUpRequestDTO.username,
                 password, signUpRequestDTO.role);
         return new SignUpResponseDTO(newUser.getId(),
                 newUser.getName(),
                 newUser.getSurname(),
-                newUser.getEmail(),
                 newUser.getUsername(),
                 newUser.getUserRole(),
                 password);
@@ -109,13 +107,11 @@ public class UserController {
     @GetMapping(value = "/user", produces = "application/json")
     public ResponseEntity<UserDto> getUser(@AuthenticationPrincipal ParkshipUserDetails userDetails) {
         ParkshipUserDetails user = ParkshipUserDetailsContext.getCurrentParkshipUserDetails();
-        return ResponseEntity.ok(new UserDto(user.getId(), user.getEmail(), user.getUsername(), user.getName(), user.getSurname(), user.getUserRole(), user.getUserState()));
+        return ResponseEntity.ok(new UserDto(user.getId(), user.getUsername(), user.getName(), user.getSurname(), user.getUserRole(), user.getUserState()));
     }
 
     @GetMapping(value = "/roles", produces = "application/json")
     public ResponseEntity<List<UserRole>> getUserRoles() {
         return ResponseEntity.ok(Arrays.asList(UserRole.values()));
     }
-
-
 }

--- a/backend/src/main/java/ch/zhaw/parkship/user/UserController.java
+++ b/backend/src/main/java/ch/zhaw/parkship/user/UserController.java
@@ -6,7 +6,6 @@ import ch.zhaw.parkship.user.exceptions.UserStateCanNotBeChanged;
 import ch.zhaw.parkship.util.ParkshipUserDetailsContext;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +26,6 @@ import java.util.List;
 public class UserController {
 
     private final UserService userService;
-    private final UserRepository userRepository;
     private final PasswordGeneratorService passwordGeneratorService;
 
 
@@ -35,16 +33,16 @@ public class UserController {
      * Record for having the users request from the frontend to sign up in one clean object.
      *
      */
-    public record SignUpRequestDTO(@NotBlank String name, @NotBlank String surname, @NotBlank String username, @NotNull UserRole role) {
+    public record SignUpRequestDTO(@NotBlank String name, @NotBlank String surname, @NotBlank String email, @NotNull UserRole role) {
     }
 
     /**
      * Record for having the response to a users sign up request in one clean object.
      *
      * @param id
-     * @param username
+     * //@param username
      */
-    public record SignUpResponseDTO(Long id, String name, String surname, String username, UserRole userRole, String password) {
+    public record SignUpResponseDTO(Long id, String name, String surname, String email, UserRole userRole, String password) {
     }
 
 
@@ -74,12 +72,12 @@ public class UserController {
     @PostMapping("/signup")
     @Secured("ADMIN")
     public SignUpResponseDTO signUp(@Valid @RequestBody SignUpRequestDTO signUpRequestDTO) {
-        if (userService.existsByUsername(signUpRequestDTO.username)) {
+        if (userService.existsByUsername(signUpRequestDTO.email)) {
             throw new ResponseStatusException(HttpStatus.CONFLICT);
         }
 
         String password = passwordGeneratorService.generatePassword();
-        UserEntity newUser = userService.signUp(signUpRequestDTO.name, signUpRequestDTO.surname, signUpRequestDTO.username,
+        UserEntity newUser = userService.signUp(signUpRequestDTO.name, signUpRequestDTO.surname, signUpRequestDTO.email,
                 password, signUpRequestDTO.role);
         return new SignUpResponseDTO(newUser.getId(),
                 newUser.getName(),

--- a/backend/src/main/java/ch/zhaw/parkship/user/UserDto.java
+++ b/backend/src/main/java/ch/zhaw/parkship/user/UserDto.java
@@ -8,11 +8,11 @@ import java.io.Serializable;
 /**
  * A DTO for the {@link UserEntity} entity
  */
-public record UserDto(Long id, @NotBlank @Email String email, @NotBlank String username, String name,
+public record UserDto(Long id, @NotBlank @Email String username, String name,
                       String surname, UserRole role, UserState userState) implements Serializable {
 
 
     public UserDto(UserEntity in) {
-        this(in.getId(), in.getEmail(), in.getUsername(), in.getName(), in.getSurname(), in.getUserRole(), in.getUserState());
+        this(in.getId(), in.getUsername(), in.getName(), in.getSurname(), in.getUserRole(), in.getUserState());
     }
 }

--- a/backend/src/main/java/ch/zhaw/parkship/user/UserDto.java
+++ b/backend/src/main/java/ch/zhaw/parkship/user/UserDto.java
@@ -8,7 +8,7 @@ import java.io.Serializable;
 /**
  * A DTO for the {@link UserEntity} entity
  */
-public record UserDto(Long id, @NotBlank @Email String username, String name,
+public record UserDto(Long id, @NotBlank @Email String email, String name,
                       String surname, UserRole role, UserState userState) implements Serializable {
 
 

--- a/backend/src/main/java/ch/zhaw/parkship/user/UserEntity.java
+++ b/backend/src/main/java/ch/zhaw/parkship/user/UserEntity.java
@@ -32,8 +32,6 @@ public class UserEntity {
     private Long id;
     @NotBlank
     @Email
-    private String email;
-    @NotBlank
     private String username;
     private String name;
     private String surname;
@@ -48,9 +46,8 @@ public class UserEntity {
     @OneToMany(mappedBy = "owner")
     private Set<ParkingLotEntity> parkingLots = new HashSet<>();
 
-    public UserEntity(String email, String username, String password) {
-        this.email = email;
-        this.username = username;
+    public UserEntity(String email, String password) {
+        this.username = email;
         this.password = password;
     }
 
@@ -72,8 +69,7 @@ public class UserEntity {
     public String toString() {
         return "User{" +
                 "id=" + id +
-                ", email='" + email + '\'' +
-                ", username='" + username +
+                ", username='" + username + '\'' +
                 '}';
     }
 

--- a/backend/src/main/java/ch/zhaw/parkship/user/UserRepository.java
+++ b/backend/src/main/java/ch/zhaw/parkship/user/UserRepository.java
@@ -9,17 +9,18 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
-    UserEntity findByEmail(String email);
+    UserEntity findByUsername(String email);
 
     @Query("select new ch.zhaw.parkship.user.ParkshipUserDetails(" +
-            "u.id, u.email, u.username, u.name, u.surname, u.password, u.userRole, u.userState) "+
-            " from UserEntity u where u.email = ?1")
-    ParkshipUserDetails getParkshipUserDetailsByEmail(String email);
+            "u.id, u.username, u.name, u.surname, u.password, u.userRole, u.userState) "+
+            " from UserEntity u where u.username = ?1")
+    ParkshipUserDetails getParkshipUserDetailsByUsername(String username);
 
 
     @Query("select new ch.zhaw.parkship.user.ParkshipUserDetails(" +
-            "u.id, u.email, u.username, u.name, u.surname, u.password, u.userRole, u.userState) "+
+            "u.id, u.username, u.name, u.surname, u.password, u.userRole, u.userState) "+
             " from UserEntity u where u.id = ?1")
     ParkshipUserDetails getParkshipUserDetailsById(Long id);
-    boolean existsByEmail(String email);
+
+    boolean existsByUsername(String username);
 }

--- a/backend/src/main/java/ch/zhaw/parkship/user/UserService.java
+++ b/backend/src/main/java/ch/zhaw/parkship/user/UserService.java
@@ -35,7 +35,7 @@ public class UserService implements UserDetailsService {
     /**
      * Save a ApplicationUser in the database.
      *
-     * @param userEntity
+     * @param userEntity to be saved
      * @return Saved applicationUser
      */
     public UserEntity save(UserEntity userEntity) {
@@ -46,13 +46,13 @@ public class UserService implements UserDetailsService {
     /**
      * Get a user from the database by username.
      *
-     * @param username
+     * @param username email adress of user
      * @return The user where username is the email address.
-     * @throws UsernameNotFoundException
+     * @throws UsernameNotFoundException email of user not found
      */
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return userRepository.getParkshipUserDetailsByEmail(username);
+        return userRepository.getParkshipUserDetailsByUsername(username);
     }
 
     /**
@@ -68,7 +68,6 @@ public class UserService implements UserDetailsService {
         UserEntity newUser = new UserEntity();
         newUser.setName(name);
         newUser.setSurname(surname);
-        newUser.setEmail(email);
         newUser.setUsername(email);
         newUser.setPassword(passwordEncoder.encode(password));
         newUser.setUserRole(userRole);
@@ -80,12 +79,12 @@ public class UserService implements UserDetailsService {
     /**
      * Checks if a users email or username already exists in the database.
      *
-     * @param email
+     * @param username email adress of user
      * @return true, if the email or username already exists in the database.
      */
 
-    public boolean existsByEmail(String email) {
-        return userRepository.existsByEmail(email);
+    public boolean existsByUsername(String username) {
+        return userRepository.existsByUsername(username);
     }
 
     public void changeUserState(Long userId, UserState userState) throws UserNotFoundException, UserStateCanNotBeChanged {

--- a/backend/src/test/java/ch/zhaw/parkship/AuthenticationControllerContextTest.java
+++ b/backend/src/test/java/ch/zhaw/parkship/AuthenticationControllerContextTest.java
@@ -39,7 +39,7 @@ class AuthenticationControllerContextTest extends AbstractDataRollbackTest {
 
     @Test
     void testSignIn() {
-        assertTrue(userService.existsByEmail("user@parkship.ch"), "Dummy user for test does not exist");
+        assertTrue(userService.existsByUsername("user@parkship.ch"), "Dummy user for test does not exist");
 
         //Existing user right password
         AuthenticationController.SignInRequestDTO signInRequestDTO = new AuthenticationController.SignInRequestDTO("user@parkship.ch", "user");
@@ -53,7 +53,6 @@ class AuthenticationControllerContextTest extends AbstractDataRollbackTest {
 
         assertThrows(BadCredentialsException.class, () -> {
             authenticationController.signIn(signInRequestDTOWrongPW);
-
         }, "No exception thrown for wrong password");
 
         //Non-existent user

--- a/backend/src/test/java/ch/zhaw/parkship/UserServiceContextTest.java
+++ b/backend/src/test/java/ch/zhaw/parkship/UserServiceContextTest.java
@@ -36,10 +36,10 @@ public class UserServiceContextTest extends AbstractDataRollbackTest {
     @Test
     public void testSignUp() {
         UserEntity userEntity = userService.signUp("test2", "test2Surname",  "test2@test.ch", "test2",  UserRole.USER);
-        assertTrue(userService.existsByEmail("test2@test.ch"), "Registered email does not exist");
-        assertEquals("test2@test.ch", userEntity.getEmail(), "Email is not correct");
+        assertTrue(userService.existsByUsername("test2@test.ch"), "Registered email does not exist");
+        assertEquals("test2@test.ch", userEntity.getUsername(), "Email is not correct");
         assertNotEquals("testtest2", userEntity.getPassword(), "Password is not encoded.");
-        UserEntity userEntity1 = userRepository.findByEmail("test2@test.ch");
+        UserEntity userEntity1 = userRepository.findByUsername("test2@test.ch");
         assertEquals(UserState.LOCKED, userEntity1.getUserState(), "Wrong default userstate");
 
     }
@@ -47,7 +47,7 @@ public class UserServiceContextTest extends AbstractDataRollbackTest {
     @Test
     public void testChangeUserState() {
         userService.signUp("test2", "test2Surname",  "test2@test.ch", "test2",  UserRole.USER);
-        UserEntity userEntity1 = userRepository.findByEmail("test2@test.ch");
+        UserEntity userEntity1 = userRepository.findByUsername("test2@test.ch");
         Long userID = userEntity1.getId();
 
         try {
@@ -55,7 +55,7 @@ public class UserServiceContextTest extends AbstractDataRollbackTest {
         } catch (Exception e) {
             fail(e);
         }
-        userEntity1 = userRepository.findByEmail("test2@test.ch");
+        userEntity1 = userRepository.findByUsername("test2@test.ch");
         assertEquals(UserState.UNLOCKED, userEntity1.getUserState());
 
         assertThrows(UserStateCanNotBeChanged.class, () -> {

--- a/backend/src/test/java/ch/zhaw/parkship/controllers/ParkingLotControllerTest.java
+++ b/backend/src/test/java/ch/zhaw/parkship/controllers/ParkingLotControllerTest.java
@@ -225,7 +225,7 @@ class ParkingLotControllerTest {
 
 
     @Test
-    public void getOwnParkingLotsTest() throws Exception {
+    public void getOwnParkingLotsTest() {
         ParkshipUserDetails user = createParkshipUserDetails(UserGenerator.generate(1L));
 
         ParkingLotDto parkingLotDto1 = new ParkingLotDto();
@@ -244,7 +244,7 @@ class ParkingLotControllerTest {
     }
 
     @Test
-    public void getOwnParkingLotsNoContentTest() throws Exception {
+    public void getOwnParkingLotsNoContentTest() {
         ParkshipUserDetails user = createParkshipUserDetails(UserGenerator.generate(1L));
 
         when(parkingLotService.getParkingLotsByUserId(eq(user.getId()))).thenReturn(Optional.empty());
@@ -255,7 +255,7 @@ class ParkingLotControllerTest {
     }
 
     @Test
-    public void getReservationsOfOwnedParkingLotsTest() throws Exception {
+    public void getReservationsOfOwnedParkingLotsTest(){
         ReservationHistoryDto expectedDto = new ReservationHistoryDto();
         ReservationDto reservationDto = new ReservationDto();
         reservationDto.setFrom(LocalDate.of(2023, 4, 10));
@@ -274,7 +274,7 @@ class ParkingLotControllerTest {
     }
 
     ParkshipUserDetails createParkshipUserDetails(UserEntity user) {
-        return new ParkshipUserDetails(user.getId(), user.getEmail(), user.getUsername(), user.getName(), user.getSurname(), user.getPassword(), user.getUserRole(), user.getUserState());
+        return new ParkshipUserDetails(user.getId(), user.getUsername(), user.getName(), user.getSurname(), user.getPassword(), user.getUserRole(), user.getUserState());
     }
 
 }

--- a/backend/src/test/java/ch/zhaw/parkship/controllers/ReservationControllerTest.java
+++ b/backend/src/test/java/ch/zhaw/parkship/controllers/ReservationControllerTest.java
@@ -107,7 +107,7 @@ class ReservationControllerTest {
     }
 
     ParkshipUserDetails createParkshipUserDetails(UserEntity user) {
-        return new ParkshipUserDetails(user.getId(), user.getEmail(), user.getUsername(), user.getName(), user.getSurname(), user.getPassword(), user.getUserRole(), user.getUserState());
+        return new ParkshipUserDetails(user.getId(), user.getUsername(), user.getName(), user.getSurname(), user.getPassword(), user.getUserRole(), user.getUserState());
     }
 
     @Test

--- a/backend/src/test/java/ch/zhaw/parkship/controllers/UserControllerTest.java
+++ b/backend/src/test/java/ch/zhaw/parkship/controllers/UserControllerTest.java
@@ -55,7 +55,7 @@ public class UserControllerTest {
         mockMvc.perform(get("/users").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk()).andExpect(jsonPath("$", hasSize(1)))
                 .andExpect(jsonPath("$[0].id", is(1)))
-                .andExpect(jsonPath("$[0].username", is("test@test.com")))
+                .andExpect(jsonPath("$[0].email", is("test@test.com")))
                 .andExpect(jsonPath("$[0].name", is("Test")))
                 .andExpect(jsonPath("$[0].surname", is("User")))
                 .andExpect(jsonPath("$[0].role", is("USER")));
@@ -78,7 +78,7 @@ public class UserControllerTest {
         assertNotNull(signUpResponseDTO, "SignUpResponseDTO is null");
         assertEquals(1L, signUpResponseDTO.id(), "User id in response is null");
         assertEquals(password, signUpResponseDTO.password(), "User password in response is null");
-        assertEquals("test@test.ch", signUpResponseDTO.username(), "Username in response is not correct");
+        assertEquals("test@test.ch", signUpResponseDTO.email(), "Username in response is not correct");
         assertEquals(UserRole.USER, signUpResponseDTO.userRole(), "Username in response is not correct");
 
         //Email already exists

--- a/backend/src/test/java/ch/zhaw/parkship/controllers/UserControllerTest.java
+++ b/backend/src/test/java/ch/zhaw/parkship/controllers/UserControllerTest.java
@@ -49,14 +49,13 @@ public class UserControllerTest {
     public void testGetAllUsers() throws Exception {
         List<UserDto> userList = new ArrayList<>();
         userList
-                .add(new UserDto(1L, "test@test.com", "testUser", "Test", "User", UserRole.USER, UserState.UNLOCKED));
+                .add(new UserDto(1L, "test@test.com", "Test", "User", UserRole.USER, UserState.UNLOCKED));
         when(userService.getAll()).thenReturn(userList);
 
         mockMvc.perform(get("/users").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk()).andExpect(jsonPath("$", hasSize(1)))
                 .andExpect(jsonPath("$[0].id", is(1)))
-                .andExpect(jsonPath("$[0].email", is("test@test.com")))
-                .andExpect(jsonPath("$[0].username", is("testUser")))
+                .andExpect(jsonPath("$[0].username", is("test@test.com")))
                 .andExpect(jsonPath("$[0].name", is("Test")))
                 .andExpect(jsonPath("$[0].surname", is("User")))
                 .andExpect(jsonPath("$[0].role", is("USER")));
@@ -67,8 +66,8 @@ public class UserControllerTest {
         String password = "1231231233";
         //New user
         when(passwordGeneratorService.generatePassword()).thenReturn(password);
-        when(userService.existsByEmail("test@test.ch")).thenReturn(false);
-        UserEntity user = new UserEntity("test@test.ch", "tester", password);
+        when(userService.existsByUsername("test@test.ch")).thenReturn(false);
+        UserEntity user = new UserEntity("test@test.ch", password);
         user.setId(1L);
         user.setUserRole(UserRole.USER);
         user.setUserState(UserState.UNLOCKED);
@@ -79,11 +78,11 @@ public class UserControllerTest {
         assertNotNull(signUpResponseDTO, "SignUpResponseDTO is null");
         assertEquals(1L, signUpResponseDTO.id(), "User id in response is null");
         assertEquals(password, signUpResponseDTO.password(), "User password in response is null");
-        assertEquals("tester", signUpResponseDTO.username(), "Username in response is not correct");
+        assertEquals("test@test.ch", signUpResponseDTO.username(), "Username in response is not correct");
         assertEquals(UserRole.USER, signUpResponseDTO.userRole(), "Username in response is not correct");
 
         //Email already exists
-        when(userService.existsByEmail("user@parkship.ch")).thenReturn(true);
+        when(userService.existsByUsername("user@parkship.ch")).thenReturn(true);
         UserController.SignUpRequestDTO signUpRequestDTOEmailExists = new UserController.SignUpRequestDTO("user", "userSurname", "user@parkship.ch",  UserRole.USER);
 
         assertThrows(ResponseStatusException.class, () -> {
@@ -91,7 +90,7 @@ public class UserControllerTest {
         }, "No exception thrown, because email already exists");
 
         //Username already exists
-        when(userService.existsByEmail("neu@neu.ch")).thenReturn(true);
+        when(userService.existsByUsername("neu@neu.ch")).thenReturn(true);
         UserController.SignUpRequestDTO signUpRequestDTOUsernameExists = new UserController.SignUpRequestDTO("neu","neuSurname","neu@neu.ch",  UserRole.USER);
 
         assertThrows(ResponseStatusException.class, () -> {

--- a/backend/src/test/java/ch/zhaw/parkship/services/ParkingLotServiceTest.java
+++ b/backend/src/test/java/ch/zhaw/parkship/services/ParkingLotServiceTest.java
@@ -65,8 +65,7 @@ class ParkingLotServiceTest {
         ReflectionTestUtils.setField(parkingLotService, "blackList", new HashSet<String>(Arrays.asList("street", "and", "the", "on", "a", "at", "be", "i", "you", "to", "it", "not", "that", "of", "do", "have", "what", "we", "in", "get", "this", "near", "close", "next")));
 
         userEntity.setId(1L);
-        userEntity.setEmail("fritz@mail.com");
-        userEntity.setUsername("fritz123");
+        userEntity.setUsername("fritz@mail.com");
         userEntity.setPassword("verysecure");
 
         parkingLotEntity = new ParkingLotEntity();
@@ -230,7 +229,7 @@ class ParkingLotServiceTest {
     @MockitoSettings(strictness = Strictness.LENIENT)
     @Test
     public void testGetBySearchTermAddress() {
-        List<ParkingLotEntity> expectedReturnValue = new ArrayList<ParkingLotEntity>();
+        List<ParkingLotEntity> expectedReturnValue = new ArrayList<>();
         expectedReturnValue.add(parkingLotEntity);
         // Mock the necessary ParkingLotRepository behavior
         when(parkingLotRepository.findAllByAddressContainsIgnoreCase("muster")).thenReturn(expectedReturnValue);
@@ -243,7 +242,7 @@ class ParkingLotServiceTest {
 
     @Test
     public void testGetBySearchTermFreeInGivenTimeFrame() {
-        List<ParkingLotEntity> expectedReturnValue = new ArrayList<ParkingLotEntity>();
+        List<ParkingLotEntity> expectedReturnValue = new ArrayList<>();
         expectedReturnValue.add(parkingLotEntity);
 
         LocalDate startDate = LocalDate.of(2023, 4, 8);
@@ -261,7 +260,7 @@ class ParkingLotServiceTest {
 
     @Test
     public void testGetBySearchTermNotFreeInGivenTimeFrame() {
-        List<ParkingLotEntity> expectedReturnValue = new ArrayList<ParkingLotEntity>();
+        List<ParkingLotEntity> expectedReturnValue = new ArrayList<>();
         expectedReturnValue.add(parkingLotEntity);
 
         LocalDate startDate = LocalDate.of(2023, 4, 8);
@@ -277,7 +276,7 @@ class ParkingLotServiceTest {
 
     @Test
     public void testGetBySearchTermPageOneEmpty() {
-        List<ParkingLotEntity> expectedReturnValue = new ArrayList<ParkingLotEntity>();
+        List<ParkingLotEntity> expectedReturnValue = new ArrayList<>();
         expectedReturnValue.add(parkingLotEntity);
 
         // Mock the necessary ParkingLotRepository and ReservationRepository behavior
@@ -289,7 +288,7 @@ class ParkingLotServiceTest {
 
     @Test
     public void testGetBySearchTermInactive(){
-        List<ParkingLotEntity> expectedReturnValue = new ArrayList<ParkingLotEntity>();
+        List<ParkingLotEntity> expectedReturnValue = new ArrayList<>();
         ParkingLotEntity p1 = new ParkingLotEntity();
         p1.setId(1L);
         p1.setState(ParkingLotState.INACTIVE);
@@ -306,7 +305,7 @@ class ParkingLotServiceTest {
 
     @Test
     public void testGetBySearchTermPageOneEntry() {
-        List<ParkingLotEntity> expectedReturnValue = new ArrayList<ParkingLotEntity>();
+        List<ParkingLotEntity> expectedReturnValue = new ArrayList<>();
         ParkingLotEntity p1 = new ParkingLotEntity();
         p1.setId(1L);
         p1.setState(ParkingLotState.ACTIVE);

--- a/backend/src/test/java/ch/zhaw/parkship/services/ReservationServiceTest.java
+++ b/backend/src/test/java/ch/zhaw/parkship/services/ReservationServiceTest.java
@@ -67,6 +67,7 @@ class ReservationServiceTest {
         parkingLotEntity.setId(1L);
         parkingLotEntity.setOwner(userEntity);
         userEntity.setId(1L);
+        userEntity.setUsername("test@test.ch");
 
         reservationEntity = new ReservationEntity();
         reservationEntity.setId(1L);
@@ -263,7 +264,7 @@ class ReservationServiceTest {
       ReservationEntity reservation2 = new ReservationEntity();
       reservation2.setId(2L);
       reservation2.setFrom(LocalDate.of(2023, 5, 8));
-      reservation2.setTo(LocalDate.of(2023, 5, 18));
+      reservation2.setTo(LocalDate.now().plusDays(1));
       reservation2.setTenant(userEntity);
       reservation2.setParkingLot(parkingLotEntity);
       reservations.add(reservation2);

--- a/backend/src/test/java/ch/zhaw/parkship/services/UserServiceTest.java
+++ b/backend/src/test/java/ch/zhaw/parkship/services/UserServiceTest.java
@@ -37,7 +37,7 @@ public class UserServiceTest {
     List<UserDto> userDtoList = userService.getAll();
     assertEquals(1, userDtoList.size());
     assertEquals(1L, userDtoList.get(0).id().longValue());
-    assertEquals("test@test.com", userDtoList.get(0).username());
+    assertEquals("test@test.com", userDtoList.get(0).email());
     assertEquals("Test", userDtoList.get(0).name());
     assertEquals("User", userDtoList.get(0).surname());
   }

--- a/backend/src/test/java/ch/zhaw/parkship/services/UserServiceTest.java
+++ b/backend/src/test/java/ch/zhaw/parkship/services/UserServiceTest.java
@@ -26,7 +26,7 @@ public class UserServiceTest {
   @Test
   public void testGetAllUsers() {
     List<UserEntity> userList = new ArrayList<>();
-    var userEntity = new UserEntity("test@test.com", "testUser", "password");
+    var userEntity = new UserEntity("test@test.com", "password");
     userEntity.setId(1L);
     userEntity.setName("Test");
     userEntity.setSurname("User");
@@ -37,8 +37,7 @@ public class UserServiceTest {
     List<UserDto> userDtoList = userService.getAll();
     assertEquals(1, userDtoList.size());
     assertEquals(1L, userDtoList.get(0).id().longValue());
-    assertEquals("test@test.com", userDtoList.get(0).email());
-    assertEquals("testUser", userDtoList.get(0).username());
+    assertEquals("test@test.com", userDtoList.get(0).username());
     assertEquals("Test", userDtoList.get(0).name());
     assertEquals("User", userDtoList.get(0).surname());
   }

--- a/backend/src/test/java/ch/zhaw/parkship/util/UserGenerator.java
+++ b/backend/src/test/java/ch/zhaw/parkship/util/UserGenerator.java
@@ -18,7 +18,6 @@ public abstract class UserGenerator {
     public static UserEntity generate(Long id) {
         return new UserEntity(id,
                 faker.internet().emailAddress(),
-                faker.name().username(),
                 faker.name().firstName(),
                 faker.name().lastName(),
                 faker.internet().password(),


### PR DESCRIPTION
## Description

<!-- Describe a reason for this PR. Why its needed? What value it will add? -->

Ich habe das Email-Feld nun mit Username ersetzt.
Ich weiss es war eigentlich anderst entschieden worden in https://pm4-zhaw.atlassian.net/wiki/spaces/PM4/pages/4947969/Decisions .  Da jedoch das org.springframework.security.core.userdetails.UserDetails Interface verwendet wird kann der Username nicht entfernt werden. Mein Vorschlag ist darum die E-Mail Adresse als Username zu verwenden.
---

## Issues

<!-- List related Github issues -->

---

## Demo

<!-- Image, video or instructions -->
